### PR TITLE
Haalcentraalmachtigen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     implementation("nl.nl-portal:data:$backend_libraries_version")
     implementation("nl.nl-portal:form-flow:$backend_libraries_version")
     implementation("nl.nl-portal:haalcentraal-brp:$backend_libraries_version")
+    implementation("nl.nl-portal:haalcentraal-all:$backend_libraries_version")
     implementation("nl.nl-portal:klant:$backend_libraries_version")
     if (!backend_libraries_version!!.equals("0.3.0.RELEASE")) {
         implementation("nl.nl-portal:klant-generiek:$backend_libraries_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,8 +71,9 @@ dependencies {
     implementation("nl.nl-portal:data:$backend_libraries_version")
     implementation("nl.nl-portal:form-flow:$backend_libraries_version")
     implementation("nl.nl-portal:haalcentraal-all:$backend_libraries_version")
-    implementation("nl.nl-portal:haalcentraal-brp:$backend_libraries_version")
-    implementation("nl.nl-portal:haalcentraal-hr:$backend_libraries_version")
+    // Below haalcentraal dependencies are implicitly added via haalcentraal-all
+    // implementation("nl.nl-portal:haalcentraal-brp:$backend_libraries_version")
+    // implementation("nl.nl-portal:haalcentraal-hr:$backend_libraries_version")
     implementation("nl.nl-portal:klant:$backend_libraries_version")
     if (!backend_libraries_version!!.equals("0.3.0.RELEASE")) {
         implementation("nl.nl-portal:klant-generiek:$backend_libraries_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,8 +70,9 @@ dependencies {
     implementation("nl.nl-portal:core:$backend_libraries_version")
     implementation("nl.nl-portal:data:$backend_libraries_version")
     implementation("nl.nl-portal:form-flow:$backend_libraries_version")
-    implementation("nl.nl-portal:haalcentraal-brp:$backend_libraries_version")
     implementation("nl.nl-portal:haalcentraal-all:$backend_libraries_version")
+    implementation("nl.nl-portal:haalcentraal-brp:$backend_libraries_version")
+    implementation("nl.nl-portal:haalcentraal-hr:$backend_libraries_version")
     implementation("nl.nl-portal:klant:$backend_libraries_version")
     if (!backend_libraries_version!!.equals("0.3.0.RELEASE")) {
         implementation("nl.nl-portal:klant-generiek:$backend_libraries_version")


### PR DESCRIPTION
Added missing dependency (-all) which has gemachtigde API.
Also added -hr, but now as -all already has -brp and -hr as dependencies it is not really needed to add them to the build explicitly. I still did it to give a better overview of whats in the template.
@petervanmanenritense @flinden68 Please share your opinion (If we should just have -all, or also include -brp & -hr)
