### PR TITLE
ARM64 docker image build support

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -92,7 +92,7 @@ jobs:
                 id: build-and-push
                 with:
                     file: Dockerfile
-                    platforms: linux/arm64/v8,linux/arm/v7,linux/amd64
+                    platforms: linux/arm64,linux/amd64
                     context: .
                     push: true
                     tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -92,6 +92,7 @@ jobs:
                 id: build-and-push
                 with:
                     file: Dockerfile
+                    platforms: linux/arm64/v8,linux/arm/v7,linux/amd64
                     context: .
                     push: true
                     tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
Added multi-platform argument to GitHub's build-push-action to start building ARM64 image variants